### PR TITLE
Updated automation for Zigbee2MQTT 1.34.0-1 compatibility

### DIFF
--- a/SLR1/config_automation/hive.yaml
+++ b/SLR1/config_automation/hive.yaml
@@ -16,7 +16,7 @@
       - service: mqtt.publish
         data:
           topic: zigbee2mqtt/heating/set
-          payload_template: '{"occupied_heating_setpoint": "{{trigger.payload}}"}' 
+          payload_template: '{"occupied_heating_setpoint": {{trigger.payload}}}' 
     - conditions:
       - condition: template
         value_template: '{{ states("sensor.heating_system_mode") == "off"}}'

--- a/SLR2/config_automation/hive.yaml
+++ b/SLR2/config_automation/hive.yaml
@@ -17,7 +17,7 @@ automation:
         - service: mqtt.publish
           data:
             topic: zigbee2mqtt/heating/set
-            payload_template: '{"occupied_heating_setpoint_heat":"{{trigger.payload}}"}' 
+            payload_template: '{"occupied_heating_setpoint_heat": {{trigger.payload}}}' 
       - conditions:
         - condition: template
           value_template: "{{ states('sensor.heating_system_mode_heating') == 'off'}}"


### PR DESCRIPTION
* This is a breaking change and requires Zigbee2MQTT 1.34.0-1 to function.
* Zigbee2MQTT 1.34.0-1 is a breaking change for the existing automation